### PR TITLE
Add support to Vehicle and Locale options

### DIFF
--- a/src/L.Routing.GraphHopper.js
+++ b/src/L.Routing.GraphHopper.js
@@ -138,8 +138,10 @@
 			var computeInstructions =
 				!(options && options.geometryOnly),
 				locs = [],
+				vehicle = this._vehicleTypes(options.vehicle),
+				locale = options.locale || 'en';
 				i;
-
+			
 			for (i = 0; i < waypoints.length; i++) {
 				locs.push('point=' + waypoints[i].latLng.lat + ',' + waypoints[i].latLng.lng);
 			}
@@ -147,8 +149,15 @@
 			return this.options.serviceUrl + '?' +
 				locs.join('&') +
 				'&instructions=' + computeInstructions +
+				'&locale=' + locale +
+				'&vehicle=' + vehicle +
 				'&type=json' +
 				'&key=' + this._apiKey;
+		},
+		
+		_vehicleTypes: function(vehicle) {
+			var _types = ['car', 'foot', 'bike'];
+			return (_types.indexOf(vehicle) == -1 ? 'car' : vehicle);
 		},
 
 		_convertInstructions: function(instructions) {

--- a/src/L.Routing.GraphHopper.js
+++ b/src/L.Routing.GraphHopper.js
@@ -139,7 +139,7 @@
 				!(options && options.geometryOnly),
 				locs = [],
 				vehicle = this._vehicleTypes(options.vehicle),
-				locale = options.locale || 'en';
+				locale = options.locale || 'en',
 				i;
 			
 			for (i = 0; i < waypoints.length; i++) {

--- a/src/L.Routing.GraphHopper.js
+++ b/src/L.Routing.GraphHopper.js
@@ -138,8 +138,8 @@
 			var computeInstructions =
 				!(options && options.geometryOnly),
 				locs = [],
-				vehicle = this._vehicleTypes(options.vehicle),
-				locale = options.locale || 'en',
+				vehicle = this._vehicleTypes(this.options.vehicle),
+				locale = this.options.locale || 'en',
 				i;
 			
 			for (i = 0; i < waypoints.length; i++) {


### PR DESCRIPTION
Now you can specify which vehicle and locale you want directly on the Graphhopper options object:

``` javascript
 L.Routing.Graphhopper('api-key', { vehicle: 'bike', locale: 'pt_PT' })
```
