### PR TITLE
Add response property to error callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   "bugs": "https://github.com/perliedman/lrm-graphhopper/issues",
   "dependencies": {
     "corslite": "0.0.6",
-    "leaflet": "^0.7.3",
     "polyline": "0.0.3"
   },
   "browserify-shim": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lrm-graphhopper",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Support for GraphHopper in Leaflet Routing Machine",
   "main": "src/L.Routing.GraphHopper.js",
   "scripts": {

--- a/src/L.Routing.GraphHopper.js
+++ b/src/L.Routing.GraphHopper.js
@@ -59,9 +59,18 @@
 						data = JSON.parse(resp.responseText);
 						this._routeDone(data, wps, callback, context);
 					} else {
+						var finalResponse;
+						var responseText = err && err.responseText;
+						try {
+							finalResponse = JSON.parse(responseText);
+						} catch (e) {
+							finalResponse = responseText;
+						}
+
 						callback.call(context || callback, {
 							status: -1,
-							message: 'HTTP request failed: ' + err
+							message: 'HTTP request failed: ' + err,
+							response: finalResponse
 						});
 					}
 				}


### PR DESCRIPTION
Dear,
Thank you for your plugin. But there is real problem - we can't handle service responses in callbacks now.

For example, use case - _specified route points is not found._
In this case GraphHopper is returning a response with HTTP code 400 and some details. But in error callback ('routingerror') we could get only those info:

``` javascript
{
  status: -1,
  message: "HTTP request failed: [object XMLHttpRequest]"
}
```

I have added just one more field to this data structure which provide us possibility to handle different responses in the right way:

``` javascript
{
  status: -1,
  message: "HTTP request failed: [object XMLHttpRequest]",
  response: "{\"message\":\"Bad Request\",\"hints\":[{\"details\":\"java.lang.IllegalArgumentException\",\"message\":\"Cannot find point 0: 37.2363025,-115.8118046\"}]}"
}
```

With this fix we could handle each possible error:

``` javascript
leafletElement.on('routingerror', event => {
  const { response } = event.error;
  try {
    const parsed = JSON.parse(response);
    if (parsed['message'] == 'Bad Request' && parsed['hints']) {
      parsed['hints'].forEach(hint => {
        if (~hint['message'].indexOf('Cannot find point')) {
          self.setState({
            hasIncorrectRoutePointsError: true
          });
        }
      });
  } catch (e) {
    // nothing;
  }
});
```
