### PR TITLE
Add options for Alternative routes

### DIFF
--- a/src/L.Routing.GraphHopper.js
+++ b/src/L.Routing.GraphHopper.js
@@ -11,6 +11,8 @@
 		options: {
 			serviceUrl: 'https://graphhopper.com/api/1/route',
 			timeout: 30 * 1000,
+			alternativeroute: false,
+			alternative_route_max_paths: "3",
 			urlParameters: {}
 		},
 
@@ -151,7 +153,9 @@
 
 			baseUrl = this.options.serviceUrl + '?' +
 				locs.join('&');
-
+			if(this._apiKey == undefined && this.options.alternativeroute && waypoints.length == 2) {
+				baseUrl += "&algorithm=alternativeroute" + "&alternative_route.max_paths=" + this.options.alternative_route_max_paths;
+			}
 			return baseUrl + L.Util.getParamString(L.extend({
 					instructions: computeInstructions,
 					type: 'json',


### PR DESCRIPTION
Make alternativeroute availble with ther options:
    alternativeroute: false,
    alternative_route_max_paths: "3",
Adds this url paramter only when there is no api_key because graphhopper does only supports altervative routes with two waypoints.
