### PR TITLE
Adds ascend to route summary

### DIFF
--- a/src/L.Routing.GraphHopper.js
+++ b/src/L.Routing.GraphHopper.js
@@ -109,6 +109,7 @@
 					summary: {
 						totalDistance: path.distance,
 						totalTime: path.time / 1000,
+            totalAscend: path.ascend,
 					},
 					inputWaypoints: inputWaypoints,
 					actualWaypoints: mappedWaypoints.waypoints,

--- a/src/L.Routing.GraphHopper.js
+++ b/src/L.Routing.GraphHopper.js
@@ -109,7 +109,7 @@
 					summary: {
 						totalDistance: path.distance,
 						totalTime: path.time / 1000,
-            totalAscend: path.ascend,
+						totalAscend: path.ascend,
 					},
 					inputWaypoints: inputWaypoints,
 					actualWaypoints: mappedWaypoints.waypoints,


### PR DESCRIPTION
# What is this PR about?
The route summary contains the ascend for a given route. The library did not pull this attribute from the response, making it unavailable for the library user.

# What is the solution?
Add ascend to the summary, next to total time and distance.

# How should I manually test this PR?
Fire up a route with the library, and now the ascend is available (if the response had it) in the summary of each route.

# Risks
Could not test with all vehicle types, but if it's unavailable, it will be `undefined`.