### PR TITLE
Fix an issue when response.info is not defined

### DIFF
--- a/src/L.Routing.GraphHopper.js
+++ b/src/L.Routing.GraphHopper.js
@@ -95,7 +95,7 @@
 			    path;
 
 			context = context || callback;
-			if (response.info.errors && response.info.errors.length) {
+			if (response.info && response.info.errors && response.info.errors.length) {
 				callback.call(context, {
 					// TODO: include all errors
 					status: response.info.errors[0].details,
@@ -155,14 +155,14 @@
 
 		buildRouteUrl: function(waypoints, options) {
 			var computeInstructions =
-				/* Instructions are always needed, 
+				/* Instructions are always needed,
 				   since we do not have waypoint indices otherwise */
 				true,
 				//!(options && options.geometryOnly),
 				locs = [],
 				i,
 				baseUrl;
-			
+
 			for (i = 0; i < waypoints.length; i++) {
 				locs.push('point=' + waypoints[i].latLng.lat + ',' + waypoints[i].latLng.lng);
 			}


### PR DESCRIPTION
According to GraphHopper API documentation, it seems the `info` field in
the response is not necessarily defined. This routing module breaks
whenever the `info` field is not defined though. This small fix handles
it.