### PR TITLE
 Adds support for out of order waypoints

### DIFF
--- a/src/L.Routing.GraphHopper.js
+++ b/src/L.Routing.GraphHopper.js
@@ -107,6 +107,13 @@
 			for (i = 0; i < response.paths.length; i++) {
 				path = response.paths[i];
 				coordinates = this._decodePolyline(path.points);
+				if (path.points_order) {
+					var tempWaypoints = [];
+					for (i = 0; i < path.points_order.length; i++) {
+						tempWaypoints.push(inputWaypoints[path.points_order[i]]);
+					}
+					inputWaypoints = tempWaypoints;
+				}
 				mappedWaypoints =
 					this._mapWaypointIndices(inputWaypoints, path.instructions, coordinates);
 


### PR DESCRIPTION
Adds support for out of order waypoints  …
Fixes UI issues due to generated waypoints being out of order from passed in waypoints. This is only a problem if the optimize url parameter is set and Graphhopper finds a shorter route through the points.

Resolves #24 